### PR TITLE
Convert CommitChange Recurring Donations to Stripe Subscriptions

### DIFF
--- a/CRM/Commitcivi/EventProcessor.php
+++ b/CRM/Commitcivi/EventProcessor.php
@@ -9,6 +9,12 @@ class CRM_Commitcivi_EventProcessor {
    * @throws \CiviCRM_API3_Exception
    */
   public function process(CRM_Commitcivi_Model_Event $event) {
+
+    if ($event->actionType == 'migrated_to_stripe') {
+      $migration = new CRM_Commitcivi_Logic_StripeMigration();
+      return $migration->migrate($event);
+    }
+
     $campaignId = $this->campaign($event);
     $contactId = $this->contact($event, $campaignId);
     switch ($event->donation->paymentProcessor) {

--- a/CRM/Commitcivi/Logic/StripeMigration.php
+++ b/CRM/Commitcivi/Logic/StripeMigration.php
@@ -1,0 +1,60 @@
+<?php
+
+class CRM_Commitcivi_Logic_StripeMigration {
+    
+
+    /**
+     * @param \CRM_Commitcivi_Model_Event $event
+     *
+     * @return integer
+     * @throws \CiviCRM_API3_Exception
+     */
+    public function migrate(CRM_Commitcivi_Model_Event $event)
+    {
+        $contact = $event->contact;
+        $donation = $event->donation;
+        
+        # find the current houdini recurring donation using email, processor, amount and start_date
+        $query = ""
+            . "SELECT recur.id recurring_id, contact.id contact_id "
+            . " FROM civicrm_contribution_recur recur "
+            . " JOIN civicrm_contact contact ON (contact.id=recur.contact_id) "
+            . " JOIN civicrm_email email ON (contact.id=email.contact_id AND email.is_primary)"
+            . "WHERE email.email = %1 "
+            . "AND payment_processor_id = 11 "
+            . "AND amount * 100 = %2 "  # units are 1s in Civi (3 euros) and 100ths (300) in Houdini 
+            . "AND left(start_date, 10) = %3 ";
+
+        $query_params = [
+            '1' => [$contact->email, 'String'],
+            '2' => [$donation->amount, 'Float'],
+            '3' => [$donation->stripeRecurringStart, 'String']
+        ];
+
+        $result = CRM_Core_DAO::executeQuery($query, $query_params);
+        $migrated = 0;
+
+        while ($result->fetch()) {
+            civicrm_api3('StripeSubscription', 'import', [
+                'subscription_id' => $donation->stripeSubscriptionId,
+                'contact_id' => $result->contact_id,
+                'payment_processor_id' => 1  # NOTE: Verify!
+            ]);
+            civicrm_api3(
+                'ContributionRecur',
+                'cancel',
+                [
+                    'id' => $result->recurring_id,
+                    'cancel_reason' => "Migrated to Stripe {$donation->stripeSubscriptionId}"
+                ]
+            );
+
+            ++$migrated;
+        }
+
+        //
+        // How do we report a warning without exiting the consumer?
+        //
+        return $migrated == 0 ? "Didn't find any recurring donations to migrate." : 1;
+    }
+}

--- a/CRM/Commitcivi/Logic/StripeMigration.php
+++ b/CRM/Commitcivi/Logic/StripeMigration.php
@@ -19,7 +19,7 @@ class CRM_Commitcivi_Logic_StripeMigration
             'get',
             [
                 'sequential' => 1,
-                'trxn_id' => $recurringId,
+                'trxn_id' => "cc_{$recurringId}",
             ]
         );
 
@@ -33,15 +33,16 @@ class CRM_Commitcivi_Logic_StripeMigration
             'import',
             [
                 'subscription_id' => $donation->stripeSubscriptionId,
-                'contact_id' => $civicrm_recurring->contactId,
-                'payment_processor_id' => CRM_Commitcivi_Logic_Settings::paymentProcessorIdCard(),
+                'contact_id' => $civicrm_recurring['values'][0]['contact_id'],
+                'payment_processor_id' => 1, # Live Stripe Account
             ]
         );
+
         civicrm_api3(
             'ContributionRecur',
             'cancel',
             [
-                'id' => $civicrm_recurring->id,
+                'id' => $civicrm_recurring['id'],
                 'cancel_reason' => "Migrated to Stripe {$donation->stripeSubscriptionId}"
             ]
         );

--- a/CRM/Commitcivi/Logic/StripeMigration.php
+++ b/CRM/Commitcivi/Logic/StripeMigration.php
@@ -1,7 +1,8 @@
 <?php
 
-class CRM_Commitcivi_Logic_StripeMigration {
-    
+class CRM_Commitcivi_Logic_StripeMigration
+{
+
 
     /**
      * @param \CRM_Commitcivi_Model_Event $event
@@ -13,7 +14,7 @@ class CRM_Commitcivi_Logic_StripeMigration {
     {
         $contact = $event->contact;
         $donation = $event->donation;
-        
+
         # find the current houdini recurring donation using email, processor, amount and start_date
         $query = ""
             . "SELECT recur.id recurring_id, contact.id contact_id "
@@ -38,7 +39,7 @@ class CRM_Commitcivi_Logic_StripeMigration {
             civicrm_api3('StripeSubscription', 'import', [
                 'subscription_id' => $donation->stripeSubscriptionId,
                 'contact_id' => $result->contact_id,
-                'payment_processor_id' => 1  # NOTE: Verify!
+                'payment_processor_id' => CRM_Commitcivi_Logic_Settings::paymentProcessorIdCard(),
             ]);
             civicrm_api3(
                 'ContributionRecur',

--- a/CRM/Commitcivi/Logic/StripeMigration.php
+++ b/CRM/Commitcivi/Logic/StripeMigration.php
@@ -2,8 +2,6 @@
 
 class CRM_Commitcivi_Logic_StripeMigration
 {
-
-
     /**
      * @param \CRM_Commitcivi_Model_Event $event
      *
@@ -12,50 +10,42 @@ class CRM_Commitcivi_Logic_StripeMigration
      */
     public function migrate(CRM_Commitcivi_Model_Event $event)
     {
-        $contact = $event->contact;
+        // $contact = $event->contact;
         $donation = $event->donation;
+        $recurringId = $event->donation->recurringId;
 
-        # find the current houdini recurring donation using email, processor, amount and start_date
-        $query = ""
-            . "SELECT recur.id recurring_id, contact.id contact_id "
-            . " FROM civicrm_contribution_recur recur "
-            . " JOIN civicrm_contact contact ON (contact.id=recur.contact_id) "
-            . " JOIN civicrm_email email ON (contact.id=email.contact_id AND email.is_primary)"
-            . "WHERE email.email = %1 "
-            . "AND payment_processor_id = 11 "
-            . "AND amount * 100 = %2 "  # units are 1s in Civi (3 euros) and 100ths (300) in Houdini 
-            . "AND left(start_date, 10) = %3 ";
+        $civicrm_recurring = civicrm_api3(
+            'ContributionRecur',
+            'get',
+            [
+                'sequential' => 1,
+                'trxn_id' => $recurringId,
+            ]
+        );
 
-        $query_params = [
-            '1' => [$contact->email, 'String'],
-            '2' => [$donation->amount, 'Float'],
-            '3' => [$donation->stripeRecurringStart, 'String']
-        ];
-
-        $result = CRM_Core_DAO::executeQuery($query, $query_params);
-        $migrated = 0;
-
-        while ($result->fetch()) {
-            civicrm_api3('StripeSubscription', 'import', [
-                'subscription_id' => $donation->stripeSubscriptionId,
-                'contact_id' => $result->contact_id,
-                'payment_processor_id' => CRM_Commitcivi_Logic_Settings::paymentProcessorIdCard(),
-            ]);
-            civicrm_api3(
-                'ContributionRecur',
-                'cancel',
-                [
-                    'id' => $result->recurring_id,
-                    'cancel_reason' => "Migrated to Stripe {$donation->stripeSubscriptionId}"
-                ]
-            );
-
-            ++$migrated;
+        if (!$civicrm_recurring) {
+            $event_as_json = json_encode($event);
+            CRM_Core_Error::fatal("Couldn't find a recurring donation for recurringId {$recurringId} {$event_as_json}");
         }
 
-        //
-        // How do we report a warning without exiting the consumer?
-        //
-        return $migrated == 0 ? "Didn't find any recurring donations to migrate." : 1;
+        civicrm_api3(
+            'StripeSubscription',
+            'import',
+            [
+                'subscription_id' => $donation->stripeSubscriptionId,
+                'contact_id' => $civicrm_recurring->contactId,
+                'payment_processor_id' => CRM_Commitcivi_Logic_Settings::paymentProcessorIdCard(),
+            ]
+        );
+        civicrm_api3(
+            'ContributionRecur',
+            'cancel',
+            [
+                'id' => $civicrm_recurring->id,
+                'cancel_reason' => "Migrated to Stripe {$donation->stripeSubscriptionId}"
+            ]
+        );
+
+        return 1;
     }
 }

--- a/CRM/Commitcivi/Model/Donation.php
+++ b/CRM/Commitcivi/Model/Donation.php
@@ -6,6 +6,7 @@ class CRM_Commitcivi_Model_Donation {
   const PAYMENT_PROCESSOR_STRIPE = 'stripe';
   const TYPE_SINGLE = 'single';
   const TYPE_RECURRING = 'recurring';
+  const TYPE_STRIPE_MIGRATION = 'migrated_to_stripe';
 
   public $amount = 0;
   public $amountCharged = 0;
@@ -25,6 +26,9 @@ class CRM_Commitcivi_Model_Donation {
   public $bic = '';
   public $accountHolder = '';
   public $bank = '';
+  public $stripeSubscriptionId = '';
+  public $stripeCustomerId = '';
+  public $stripeRecurringStart = '';
 
   public function __construct($params) {
     $donation = $this->get($params);
@@ -43,6 +47,9 @@ class CRM_Commitcivi_Model_Donation {
     $this->bic = property_exists($donation, 'bic') ? $donation->bic : $this->bic;
     $this->accountHolder = property_exists($donation, 'account_holder') ? $donation->account_holder : $this->accountHolder;
     $this->bank = property_exists($donation, 'bank') ? $donation->bank : $this->bank;
+    $this->stripeSubscriptionId = property_exists($donation, 'stripe_subscription_id') ? $donation->stripe_subscription_id : $this->stripeSubscriptionId;
+    $this->stripeCustomerId = property_exists($donation, 'stripe_customer_id') ? $donation->stripe_customer_id : $this->stripeCustomerId;
+    $this->stripeRecurringStart = property_exists($donation, 'stripe_recurring_start') ? $donation->stripe_recurring_start : $this->stripeRecurringStart;
   }
 
   /**


### PR DESCRIPTION
CommitChange-ini will sent messages to the commitchange queue to notify us that a Stripe subscription has been created. The new StripeMigration class handles importing the Stripe subscription into CiviCRM and cancelling the existing recurring donation.

This code expects to run *after* Change-ini has sent a message to create the recurring donation. 